### PR TITLE
Fix NPE for AOption.some(null).toOptional()

### DIFF
--- a/a-collections/src/main/java/com/ajjpj/acollections/util/AOption.java
+++ b/a-collections/src/main/java/com/ajjpj/acollections/util/AOption.java
@@ -289,7 +289,7 @@ public abstract class AOption<T> implements ACollectionDefaults<T, AOption<T>>, 
         }
 
         @Override public Optional<T> toOptional () {
-            return Optional.of(el);
+            return Optional.ofNullable(el);
         }
 
         @Override public AIterator<T> iterator () {

--- a/a-collections/src/test/java/com/ajjpj/acollections/util/AOptionTest.java
+++ b/a-collections/src/test/java/com/ajjpj/acollections/util/AOptionTest.java
@@ -92,6 +92,7 @@ public class AOptionTest implements ACollectionOpsTests {
 
     @Test void testToOptional() {
         assertEquals(Optional.empty(), none().toOptional());
+        assertEquals(Optional.empty(), some(null).toOptional());
         assertEquals(Optional.of("a"), some("a").toOptional());
     }
 


### PR DESCRIPTION
AOption may contain null values witch is not true for
java.util.Optional.

AOption.toOptional() now treats this case as java.util.Optional.empty()
to avoid producing a NullPointerException.